### PR TITLE
Bs slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Import the module
 Then run any of the available modes:
 * Move mouse pointer from right to left for 10 seconds: `activate_conga_office(duration=10, pattern='linear')` or `activate_conga_office(duration=10)` 
 * Move mouse pointer in diamond shape for 20 seconds: `activate_conga_office(duration=20, pattern='diamond')`
-* Move mouse pointer in circles for 5 seconds: `activate_conga_office(duration=5, pattern='circle')`
+* Move mouse pointer in circles for 5 seconds: `activate_conga_office(duration=5, pattern='circular')`
 * Move mouse pointer in randomly for 10 seconds: `activate_conga_office(duration=10, pattern='random')`
 
 To move faster or slower set `speed='turbo'` or `speed='slow'` respectively. E.G.
 `activate_conga_office(duration=10, pattern='diamond', speed='turbo')`
 
-## Sending corporate jargon via Teams
+## Sending corporate jargon via Teams (Windows)
 This is a function only available for Windows 10 users who use Microsoft Teams. If you want yo send 
 10 messages at intervals of 2 seconds (it is recommended at least 2 seconds of interval between messages)
 to a contact whose id is `a_name.a_surname` then apply the following code:
@@ -33,6 +33,23 @@ send_bs_via_teams(
   intervals_in_secs=2)
 ```
 
+## Sending corporate jargon via Slack (macOS)
+
+This is a function only available for macOS users who use Slack. If you want yo send 
+10 messages at intervals of 2 seconds (it is recommended at least 2 seconds of interval between messages)
+to a contact whose fortunate name is Elvis Presley then apply the following code:
+
+```
+from conga_office.tools import send_bs_via_slack
+send_bs_via_slack(
+  contact_id = 'Elvis Presley', 
+  number_of_bs_statements = 5, 
+  intervals_in_secs=2)
+```
+
+
+
 # Future endeavors
+
 * Create flamboyant Power Point presentations.
 * Build internal colloquial bs generator.

--- a/src/conga_office/tools.py
+++ b/src/conga_office/tools.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 import requests
 from conga_office.config.metadata import valid_speed_modes, teams_search_key, bs_generator_api, waiting_intervals
+import os
 
 
 def get_speed(speed_value: str):
@@ -178,3 +179,52 @@ def send_bs_via_teams(contact_id: str,
         pyautogui.typewrite(['enter', 'enter'])
         time.sleep(waiting_intervals)
         time.sleep(intervals_in_secs)
+
+
+def find_slack_macOS():
+  """
+  Open slack.
+  :return:
+  """
+  os.system("open -a Slack")
+
+
+def open_slack_chat_with_contact(contact_id: str):
+  """
+  Open teams' chat window with contact
+  :param contact_id:
+  :return:
+  """
+  find_slack_macOS()
+  time.sleep(waiting_intervals)
+  pyautogui.hotkey('enter')
+  pyautogui.hotkey('command', 'g')
+  time.sleep(waiting_intervals)
+  pyautogui.typewrite(contact_id)
+  time.sleep(waiting_intervals)
+  pyautogui.press('down')
+  time.sleep(waiting_intervals)
+  pyautogui.press('enter')
+
+
+def send_bs_via_slack(contact_id: str,
+                      number_of_bs_statements: int,
+                      intervals_in_secs: float,
+                      bs_generator_url: str = bs_generator_api):
+  """
+
+  :param bs_generator_url:
+  :param contact_id:
+  :param number_of_bs_statements:
+  :param intervals_in_secs:
+  :return:
+  """
+  open_slack_chat_with_contact(contact_id=contact_id)
+  for _ in range(number_of_bs_statements):
+    bs_request = requests.get(bs_generator_url)
+    bs_msg = bs_request.json()['phrase']
+    pyautogui.typewrite(bs_msg)
+    time.sleep(waiting_intervals)
+    pyautogui.typewrite(['enter', 'enter'])
+    time.sleep(waiting_intervals)
+    time.sleep(intervals_in_secs)

--- a/tests/unit/tools.py
+++ b/tests/unit/tools.py
@@ -1,6 +1,6 @@
 import os
 
-from src.conga_office.tools import activate_conga_office, send_bs_via_teams
+from src.conga_office.tools import activate_conga_office, send_bs_via_teams, send_bs_via_slack
 
 
 def test_linear_pattern():
@@ -25,4 +25,9 @@ def test_circular_pattern():
 
 def test_teams_bs_generator():
     send_bs_via_teams(os.environ['CONTACT_ID'], 5, 2)
+    assert True
+
+
+def test_slack_bs_generator():
+    send_bs_via_slack(contact_id='Test Name', number_of_bs_statements=2, intervals_in_secs=2)
     assert True


### PR DESCRIPTION
Added bs generator for Slack (MacOS). Also, corrected a readme typo in "circular", instead of "circle" as pattern name.